### PR TITLE
Set up build and push to ACR Azure pipeline

### DIFF
--- a/azure-pipelines/build-and-push-to-acr.yml
+++ b/azure-pipelines/build-and-push-to-acr.yml
@@ -1,0 +1,45 @@
+# Docker
+# Build and push an image to Azure Container Registry
+# https://docs.microsoft.com/azure/devops/pipelines/languages/docker
+
+# Trigger only on pushed tags
+trigger:
+  tags:
+    include:
+      - '*'
+  branches:
+    exclude:
+      - '*'
+
+resources:
+- repo: self
+
+variables:
+  # Container registry service connection established during pipeline creation
+  dockerRegistryServiceConnection: 'f1ee33f8-204d-4b8e-8fbd-27449940999a'
+  imageRepository: 'reledger-api'
+  containerRegistry: 'almgruacr.azurecr.io'
+  dockerfilePath: '$(Build.SourcesDirectory)/Dockerfile'
+  tag: '$(Build.SourceBranchName)'
+
+  # Agent VM image name
+  vmImageName: 'ubuntu-20.04'
+
+stages:
+- stage: Build
+  displayName: Build and push stage
+  jobs:
+  - job: Build
+    displayName: Build
+    pool:
+      vmImage: $(vmImageName)
+    steps:
+    - task: Docker@2
+      displayName: Build and push an image to container registry
+      inputs:
+        command: buildAndPush
+        repository: $(imageRepository)
+        dockerfile: $(dockerfilePath)
+        containerRegistry: $(dockerRegistryServiceConnection)
+        tags: |
+          $(tag)


### PR DESCRIPTION
The pipeline is triggered when git tags are pushed and pushes the image to the `reledger-api` repository on the
`almgru.azurecr.io` container registry. The name of the docker image tag is the same as the pushed git tag.